### PR TITLE
(docs) Adds Debian specific config location

### DIFF
--- a/documentation/install_from_packages.markdown
+++ b/documentation/install_from_packages.markdown
@@ -44,9 +44,14 @@ Puppet Server is configured to use 2GB of RAM by default. If you'd like to just 
 
 ## Memory Allocation
 
-By default, Puppet Server will be configured to use 2GB of RAM. However, if you want to experiment with Puppet Server on a VM, you can safely allocate as little as 512MB of memory. To change the Puppet Server memory allocation:
+By default, Puppet Server will be configured to use 2GB of RAM. However, if you want to experiment with Puppet Server on a VM, you can safely allocate as little as 512MB of memory. To change the Puppet Server memory allocation, you can edit the init config file. 
 
-1. Open `/etc/sysconfig/puppetserver` and modify these settings:
+### Location 
+
+* `/etc/sysconfig/puppetserver` - RHEL
+* `/etc/default/puppetserver` - Debian 
+
+1. Open the init config file: 
 
         # Modify this if you'd like to change the memory allocation, enable JMX, etc
         JAVA_ARGS="-Xms2g -Xmx2g"


### PR DESCRIPTION
As someone not super familir to Debian file defaults, had to do a bit of searching to find out how to set puppetserver memory on Ubuntu! :smile: 

I did it as a bulletpoint list for if this is at a different location on other OS's and can be easily added in the future 
